### PR TITLE
Add TypeScript declaration file

### DIFF
--- a/prism-markdown-element.d.ts
+++ b/prism-markdown-element.d.ts
@@ -1,0 +1,52 @@
+import { LitElement } from 'lit-element/lit-element.js';
+
+/**
+ * @customElement prism-markdown-element
+ */
+export declare class PrismMarkdownElement extends LitElement {
+
+    safe: boolean;
+    mdsrc: string;
+    markdown: string;
+    theme: string;
+    customtheme: string;
+    __styles: string;
+    __markdownRendered: string;
+    __reader: any;
+    __writer: any;
+
+    /**
+     * @method fetchMd
+     * @description method to fetch markdown from a url or path
+     * @param {String} src markdown url
+     * @return {Promise}
+     */
+    fetchMd(src: string): Promise<any>;
+
+    /**
+     * @method fetchStyles
+     * @description method to fetch styles from a url or path
+     * @param {Object} config - config to fetch styles required
+     * @param {String} config.url url with the style theme
+     * @param {String} config.theme name of the prismjs theme
+     * @return {Promise}
+     */
+    fetchStyles({ url, theme }: {
+        url: string;
+        theme: string;
+    }): Promise<any>;
+
+    /**
+     * @method parseMarkdown
+     * @description parse markdown string to html content
+     * @param {String} markdown string with markdown content
+     * @return {Object} html template string
+     */
+    parseMarkdown(markdown: string): Object;
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "prism-markdown-element": PrismMarkdownElement;
+    }
+}


### PR DESCRIPTION
Otherwise TypeScript compiler will spit a warning like below:

> TS7016: Could not find a declaration file for module 'prism-markdown-element/prism-markdown-element.js'. '/home/you/project/node_modules/prism-markdown-element/prism-markdown-element.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/prism-markdown-element` if it exists or add a new declaration (.d.ts) file containing `declare module 'prism-markdown-element/prism-markdown-element.js';`

Detail: https://stackoverflow.com/q/41292559

Also running https://github.com/runem/lit-analyzer will spit warnings like below:
```
    Unknown tag <prism-markdown-element>.
    47:  <prism-markdown-element markdown="${
    no-unknown-tag-name
```
Detail: https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md#-no-unknown-tag-name

This declaration file will clear out those warnings.